### PR TITLE
Keep the `brush` of parallel coordinates when each visible of layer is changed

### DIFF
--- a/private/jsx/pcoords/pcoords.js
+++ b/private/jsx/pcoords/pcoords.js
@@ -19,7 +19,7 @@ class PCoords extends React.Component {
         this.calcRanges = this.calcRanges.bind(this);
     }
     componentWillReceiveProps(nprops){
-        if(true && nprops.layers.length > 0){
+        if(!this.state.started && nprops.layers.length > 0){ 
             this.setState({started: true});
 
             const bounds = nprops.layers[0].bounds;

--- a/private/jsx/pcoords/pcoords.js
+++ b/private/jsx/pcoords/pcoords.js
@@ -19,6 +19,7 @@ class PCoords extends React.Component {
         this.calcRanges = this.calcRanges.bind(this);
     }
     componentWillReceiveProps(nprops){
+        // if(true && nprops.layers.length > 0){ 
         if(!this.state.started && nprops.layers.length > 0){ 
             this.setState({started: true});
 


### PR DESCRIPTION
When the layer is turned off, and on, the parallel coordinates widget loses the `brushed` property. Keep track of the property so it does not restart.