### PR TITLE
apply babel plugin 'transform-class-properties'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,12 @@ gulp.task('build', function() {
         extensions: ['.js'],
         debug: true
     })
-    .transform(babelify, {presets: ['es2015', 'react']})
+    .transform(babelify, {
+        presets: ['es2015', 'react'],
+        plugins: [
+            'transform-class-properties',
+        ],
+    })
     .bundle()
     .on('error', errHandler)
     .pipe(source('bundle.js'))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,10 @@ module.exports = {
                     loader: 'babel-loader',
                     options: {
                         presets: ['es2015', 'react'],
-                        plugins: ['transform-runtime'],
+                        plugins: [
+                            'transform-runtime',
+                            'transform-class-properties',
+                        ],
                         // This is a feature of `babel-loader` for webpack (not Babel itself).
                         // It enables caching results in ./node_modules/.cache/babel-loader/
                         // directory for faster rebuilds.


### PR DESCRIPTION
## Using this [plugin](https://babeljs.io/docs/plugins/transform-class-properties/) for babel

According to this article [React on ES6+](https://babeljs.io/blog/2015/06/07/react-on-es6-plus#arrow-functions) from babel blog

---

Since we don’t involve the React.createClass method when we define components using the ES6+ class syntax, it would seem that we need to manually bind instance methods. Now, combining two ES6+ features – **arrow functions** and **property initializers** .

## Example

### Before

``` javascript
// Manually bind, wherever you need to

class PostInfo extends React.Component {
  constructor(props) {
    super(props);
    // Manually bind this method to the component instance...
    this.handleOptionsButtonClick = this.handleOptionsButtonClick.bind(this);
  }
  handleOptionsButtonClick(e) {
    // ...to ensure that 'this' refers to the component instance here.
    this.setState({showOptionsModal: true});
  }
}
```


### After

``` javascript
class PostInfo extends React.Component {
  handleOptionsButtonClick = (e) => {
    this.setState({showOptionsModal: true});
  }
}
```