### PR TITLE
[Testing] use `webpack build` to replace `gulp build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "cross-env NODE_ENV=development node ./bin/www",
-    "build": "gulp build",
+    "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "start": "cross-env NODE_ENV=production node ./bin/www",
     "lint": "eslint . --color",
     "lint:fix": "eslint . --color --fix --debug",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,8 +10,9 @@ module.exports = {
         './private/jsx/entry.js',
     ],
     output: {
-        path: path.resolve(__dirname, './public/'),
-        publicPath: '/javascripts/',
+        path: path.resolve(__dirname, './public/javascripts/'),
+        // publicPath: 'CDN.../javascripts/',
+        // In development Environment:
         // This does not produce a real file. It's just the virtual path that is
         // serve in development. This is the JS bundle
         // containing code from all our entry points, and the Webpack runtime.
@@ -115,4 +116,24 @@ module.exports = {
     // splitting or minification in interest of speed. These warnings become
     // cumbersome.
     devtool: '#eval-source-map',
+}
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports.devtool = '#source-map'
+  module.exports.plugins = (module.exports.plugins || []).concat([
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"',
+      },
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      sourceMap: true,
+      compress: {
+        warnings: false,
+      },
+    }),
+    new webpack.LoaderOptionsPlugin({
+      minimize: true,
+    }),
+  ])
 }


### PR DESCRIPTION
I am not sure whether the new webpack config is right.
So we should run it on the server mode to check the new bundle.js file is worked correctly.

it might reduce the file size of `bundle.js`
> 15.6 Mb -> 1.06 Mb