### PR TITLE
Add script `init:db` to init database

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm install -g gulp-cli
     ECHO $EMAILPASSWORD`
 
 ## Starting the Server
-* Run the following command to create the datbase files:
+* Run the following command to create the database files:
 ```
 $ cd app
 $ sequelize db:migrate

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "init:db": "cd app && sequelize db:migrate",
     "dev": "cross-env NODE_ENV=development node ./bin/www",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "start": "cross-env NODE_ENV=production node ./bin/www",


### PR DESCRIPTION
### Summary
- Now, developers can use `yarn init:db` or `npm run init:db` to setup the database.
> `yarn init:db` or `npm run init:db`
- Besides, because the `npm` or `yarn` run the scripts from the `node_modules/`, developers don't have to install global `sequelize-cli` i think. (*we have added the `sequelize-cli` to the dependency.*)
